### PR TITLE
multiple invokings in the same session makes response dirty

### DIFF
--- a/src/EpiApi.php
+++ b/src/EpiApi.php
@@ -47,6 +47,8 @@ class EpiApi
     foreach($tmps as $type => $value)
       $GLOBALS[$type] = $value; 
 
+    // unset response to prevent contamination on multpile invokings in the same session
+    unset($GLOBALS["response"]);
     return $retval;
   }
 


### PR DESCRIPTION
I unset response to prevent contamination on multpile invokings in the same session. Not sure if this is the best way to do it but it is working for my case.
