### PR TITLE
API behaviour with NULL

### DIFF
--- a/src/EpiRoute.php
+++ b/src/EpiRoute.php
@@ -134,7 +134,13 @@ class EpiRoute
     if(!$routeDef['postprocess'])
       return $response;
     else
-      echo json_encode($response);
+    {
+      // Only echo the response if it's not null. 
+      if (!is_null($response))
+      {
+        echo json_encode($response);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
I changed the behaviour of API methods returning NULL. In my opinion, null may not be echoed to the user/consumer of the webservice. Wo I only echo the content if it's not null. 
The changes do not affect the api call if you call it with "invoke".
