### PR TITLE
[proposal] jsonp callback

### DIFF
--- a/src/EpiRoute.php
+++ b/src/EpiRoute.php
@@ -138,7 +138,9 @@ class EpiRoute
       // Only echo the response if it's not null. 
       if (!is_null($response))
       {
-        echo json_encode($response);
+        $response = json_encode($response);
+        if(isset($_GET['callback'])) $response = "{$_GET['callback']}($response)";
+        echo $response;
       }
     }
   }


### PR DESCRIPTION
You have great `EpiApi` class which do very good job, until I want to make java script requests from another domain

Use case example:

``` php

<?php

include_once 'epiphany/src/Epi.php';
Epi::setPath('base', 'epiphany/src');
Epi::init('config', 'api', 'route');

getConfig()->set('base', '/rest');

getRoute()->get('/users', 'showUsers');
getApi()->get('/users.json', 'apiUsers', EpiApi::external);
getRoute()->run();

function apiUsers() {
    return array('Alex', 'Jim', 'Santa');
}

function showUsers() {
    echo implode(', ', apiUsers());
}
```
### /users

```
Alex, Jim, Santa
```
### /users.json

```
["Alex", "Jim", "Santa"]
```
### /users.json?callback=cb

```
cb(["Alex", "Jim", "Santa"])
```
### calling from another domain

```
$.getJSON('http://example.com/users.json?callback=?', function(data){
    alert(data.join(', '));
});
```
