### PR TITLE
Using DIRECTORY_SEPARATOR instead of hard coding the slash

### DIFF
--- a/src/Epi.php
+++ b/src/Epi.php
@@ -65,7 +65,7 @@ class Epi
     if(!is_array($value))
     {
       if(!isset(self::$included[$value]))
-        include(self::getPath('base') . "/{$value}");
+        include(self::getPath('base') . DIRECTORY_SEPARATOR . "{$value}");
       self::$included[$value] = 1;
     }
     else

--- a/src/EpiCache.php
+++ b/src/EpiCache.php
@@ -19,7 +19,7 @@ class EpiCache
       return self::$instances[$hash];
 
     $type = array_shift($params);
-    if(!file_exists($file = dirname(__FILE__) . "/{$type}.php"))
+    if(!file_exists($file = dirname(__FILE__) . DIRECTORY_SEPARATOR . "{$type}.php"))
       EpiException::raise(EpiCacheTypeDoesNotExistException("EpiCache type does not exist: ({$type}).  Tried loading {$file}", 404));
 
     require_once $file;

--- a/src/EpiConfig.php
+++ b/src/EpiConfig.php
@@ -14,8 +14,8 @@ class EpiConfig
     foreach($args as $file)
     {
       // Prepend config directory if the path doesn't start with . or /
-      if($file[0] != '.' && $file[0] != '/')
-        $file = Epi::getPath('config') . "/{$file}";
+      if($file[0] != '.' && $file[0] != DIRECTORY_SEPARATOR)
+        $file = Epi::getPath('config') . DIRECTORY_SEPARATOR . "{$file}";
 
       if(!file_exists($file))
       {

--- a/src/EpiRoute.php
+++ b/src/EpiRoute.php
@@ -94,7 +94,7 @@ class EpiRoute
    */
   public function load($file)
   {
-    $file = Epi::getPath('config') . "/{$file}";
+    $file = Epi::getPath('config') . DIRECTORY_SEPARATOR . "{$file}";
     if(!file_exists($file))
     {
       EpiException::raise(new EpiException("Config file ({$file}) does not exist"));

--- a/src/EpiTemplate.php
+++ b/src/EpiTemplate.php
@@ -16,7 +16,7 @@ class EpiTemplate
     {
       extract($vars);
     }
-    $templateInclude = Epi::getPath('view') . '/' . $template;
+    $templateInclude = Epi::getPath('view') . DIRECTORY_SEPARATOR . $template;
     if(is_file($templateInclude))
     {
       include $templateInclude;
@@ -41,7 +41,7 @@ class EpiTemplate
    */
   public function get($template = null, $vars = null)
   {
-    $templateInclude = Epi::getPath('view') . '/' . $template;
+    $templateInclude = Epi::getPath('view') . DIRECTORY_SEPARATOR . $template;
     if(is_file($templateInclude))
     {
       if(is_array($vars))


### PR DESCRIPTION
To support a wider install base its best to use DIRECTORY_SEPARATOR instead of hard coding the slash
