### PR TITLE
Adding session_id( ) check to session_start( ) call

### DIFF
--- a/src/EpiSession_Php.php
+++ b/src/EpiSession_Php.php
@@ -32,6 +32,7 @@ class EpiSession_Php implements EpiSessionInterface
 
   public function __construct()
   {
-    session_start();
+    if (!session_id())
+      session_start();
   }
 }


### PR DESCRIPTION
Make sure that if someone else starts a session, that a new session is not started again.  The duplicate call to session_start produces a php warning.
