### PR TITLE
add support for multiple memcache servers and options to EpiSession

### DIFF
--- a/src/EpiSession_Memcached.php
+++ b/src/EpiSession_Memcached.php
@@ -3,7 +3,13 @@ class EpiSession_Memcached implements EpiSessionInterface
 {
   private static $connected = false;
   private $key  = null;
-  private $store= null;
+  private $store = null;
+
+  private $host = null;
+  private $port = null;
+  private $compress = null;
+  private $expiry = null;
+  private $options = null;
 
   public function __construct($params = array())
   {
@@ -13,10 +19,12 @@ class EpiSession_Memcached implements EpiSessionInterface
       setcookie(EpiSession::COOKIE, $cookieVal, time()+1209600, '/');
       $_COOKIE[EpiSession::COOKIE] = $cookieVal;
     }
+
     $this->host = !empty($params[0]) ? $params[0] : 'localhost';
-    $this->port = !empty($params[1]) ? $params[1] : 11211;;
-    $this->compress = !empty($params[2]) ? $params[2] : 0;;
+    $this->port = !empty($params[1]) ? $params[1] : 11211;
+    $this->compress = !empty($params[2]) ? $params[2] : 0;
     $this->expiry   = !empty($params[3]) ? $params[3] : 3600;
+    $this->options  = !empty($params[4]) ? $params[4] : array();
   }
 
   public function end()
@@ -51,7 +59,7 @@ class EpiSession_Memcached implements EpiSessionInterface
       return false;
     
     $this->store[$key] = $value;
-    $this->memcached->set($this->key, $this->store);
+    $this->memcached->set($this->key, $this->store, time() + $this->expiry);
     return $value;
   }
 
@@ -63,10 +71,38 @@ class EpiSession_Memcached implements EpiSessionInterface
     if(class_exists('Memcached'))
     {
       $this->memcached = new Memcached;
-      if($this->memcached->addServer($this->host, $this->port))
+
+      if(count($this->host) !== count($this->port))
+        EpiException::raise(new EpiSessionMemcacheConnectException('Multiple servers require the same nubmber of hosts & ports'));
+
+      $servers = array();
+
+      // list of both host and port
+      if(is_array($this->host) && is_array($this->port))
+        foreach($this->host as $i => $host)
+          $servers[] = array($host, $this->port[$i]);
+
+      // all hosts with the same port
+      elseif(is_array($this->host) && is_scalar($this->port))
+        foreach($this->host as $i => $host)
+          $servers[] = array($host, $this->port);
+
+      // one host with multiple ports
+      elseif(is_scalar($this->host) && is_array($this->port))
+        foreach($this->port as $i => $port)
+          $servers[] = array($this->host, $port);
+
+      // single server
+      else
+        $servers[] = array($this->host, $this->port);
+
+      foreach($this->options as $name => $value)
+        $this->memcached->setOption($name, $value);
+
+      if($this->memcached->addServers($servers))
       {
         self::$connected = true;
-        $this->key = empty($key) ? $_COOKIE[EpiSession::COOKIE] : $key;
+        $this->key = $_COOKIE[EpiSession::COOKIE];
         $this->store = $this->getAll();
         return true;
       }


### PR DESCRIPTION
Added support to allow for multiple servers and set memcached options.

 $hosts = array( 'host1', 'host2' );
 $ports = array( 11211, 11212 );
 $options =  array( Memcached::OPT_DISTRIBUTION => Memcached::DISTRIBUTION_CONSISTENT,
                            Memcached::OPT_LIBKETAMA_COMPATIBLE => true );

 EpiSession::employ( EpiSession::MEMCACHED, $hosts, $ports, false, 86400, $options );

Also supports array of 1 -> N:

 EpiSession::employ( EpiSession::MEMCACHED, $hosts );
