### PR TITLE
Added handling of JSON errors for postprocessing

### DIFF
--- a/src/EpiRoute.php
+++ b/src/EpiRoute.php
@@ -139,6 +139,13 @@ class EpiRoute
       if (!is_null($response))
       {
         $response = json_encode($response);
+        
+        if(!$response) {
+          if(function_exists('json_last_error_msg'))
+            echo json_encode(array('error' => json_last_error_msg()));
+          else
+            echo json_encode(array('error' => "A JSON Parsing Error has occurred"));
+        }
         if(isset($_GET['callback']))
           $response = "{$_GET['callback']}($response)";
         else


### PR DESCRIPTION
The odd UTF8 error or otherwise can cause nothing to output and you have no idea what the error could be. This outputs an error message if the framework failed to encode the json response successfully.

A fallback is also provided for pre-PHP5.5.0 support, as json_last_error_msg() is only in >=5.5
