### PR TITLE
use a session manager without calling employ()

### DIFF
--- a/src/EpiSession.php
+++ b/src/EpiSession.php
@@ -55,7 +55,8 @@ if(!function_exists('getSession'))
   function getSession()
   {
     $employ = EpiSession::employ();
-    $class = array_shift($employ);
+    if($employ !== null)
+      $class = array_shift($employ);
     if($employ && class_exists($class))
       return EpiSession::getInstance($class, $employ);
     elseif(class_exists(EpiSession::PHP))


### PR DESCRIPTION
Warning: array_shift() expects parameter 1 to be array, null given in EpiSession.php on line 58

If you initialize one, and only one, of the session implementations, you should not have to call employ().

Epi::init('session-apc');
getSession()->set('this','that');

that code would generate a warning because employ is called without an argument so it returns null. array_shift() is then called on $employ which causes the warning. I think this could be cleaned up more, but this is a quick fix.